### PR TITLE
Update utils.py

### DIFF
--- a/src/liger_kernel/ops/flash_attention/utils.py
+++ b/src/liger_kernel/ops/flash_attention/utils.py
@@ -78,7 +78,7 @@ def infer_bias_strides(
             raise ValueError(f"Attention bias has {bias.size(0) = } while {batch = }")
         if bias.size(1) == 1:
             stride_bh = 0
-        elif bias.stride(1) == nheads_q:
+        elif bias.size(1) == nheads_q:
             stride_bh = bias.stride(1)
         else:
             raise ValueError(


### PR DESCRIPTION
Debugs bias stride.

## Summary
Makes a small change to get the correct Bias stride.

## Testing Done
```
from kernels.liger.wrapper import flash_attn_func as liger_flash_attn_func
from torch.nn.functional import scaled_dot_product_attention

q = torch.randn(bsz, num_heads, seqlen_q, head_dim, device="cuda", dtype=torch.float16).requires_grad_()# [batch_size, seqlen_q, num_heads_q, head_dim]
k = torch.randn(bsz, num_heads, seqlen_kv, head_dim, device="cuda", dtype=torch.float16).requires_grad_()# [batch_size, seqlen_q, num_heads_kv, head_dim]
v = torch.randn(bsz, num_heads, seqlen_kv, head_dim, device="cuda", dtype=torch.float16).requires_grad_()# [batch_size, seqlen_q, num_heads_kv, head_dim]

b = torch.randn(bsz, num_heads, seqlen_q, seqlen_kv, device="cuda", dtype=torch.float16).requires_grad_()


liger_out = liger_flash_attn_func(q.transpose(1,2), k.transpose(1,2), v.transpose(1,2), attention_bias=b, softmax_scale= 0.5).transpose(1,2)

ref_out = scaled_dot_product_attention(q, k, v, b, scale=0.5)
torch.allclose(ref_out, liger_out, atol=1e-2, rtol=0)

ref_out.backward(dout)
ref_dv, v.grad = v.grad.clone(), None

liger_out.backward(dout)
dv, v.grad = v.grad.clone(), None

torch.allclose(ref_out, liger_out, atol=1e-2, rtol=0.0), torch.allclose(ref_dv, dv, atol=1e-2, rtol=0.0)
```

